### PR TITLE
Bugfix/string data

### DIFF
--- a/Sources/String+URI.swift
+++ b/Sources/String+URI.swift
@@ -88,7 +88,7 @@ extension String {
     }
 
     public var data: [Int8] {
-        return self.utf8.map { Int8($0) }
+        return self.utf8.map { Int8(bitPattern: $0) }
     }
 
     public func splitBy(separator: Character, allowEmptySlices: Bool = false) -> [String] {

--- a/Tests/URITests.swift
+++ b/Tests/URITests.swift
@@ -41,4 +41,10 @@ class URITests: XCTestCase {
         XCTAssert(uri2.path == "/api/v1/tasks")
         XCTAssert(uri2.query["done"] == "true")
     }
+
+    func testStringDataEncoding() {
+        let string = String(UnicodeScalar(255)) // ÿ
+        let stringBytes: [UInt8] = [0xC3, 0xBF]
+        XCTAssertEqual(string.data, stringBytes.map { Int8(bitPattern: $0) })
+    }
 }


### PR DESCRIPTION
There was a bug, where `String.data` would overflow `Int8` if `String.utf8` had characters with `CharacterCode > 127`
