### PR TITLE
Fix query optionals not unwrapping when converted to String.

### DIFF
--- a/Sources/URI.swift
+++ b/Sources/URI.swift
@@ -161,7 +161,7 @@ extension URI: CustomStringConvertible {
         }
 
         for (offset: index, element: queryElement) in query.enumerated() {
-            string += "\(queryElement.key)=\(queryElement.value)"
+            string += "\(queryElement.key)=\(queryElement.value ?? "")"
             if index != query.count - 1 {
                 string += "&"
             }

--- a/Sources/URI.swift
+++ b/Sources/URI.swift
@@ -161,7 +161,10 @@ extension URI: CustomStringConvertible {
         }
 
         for (offset: index, element: queryElement) in query.enumerated() {
-            string += "\(queryElement.key)=\(queryElement.value ?? "")"
+            string += "\(queryElement.key)"
+            if let value = queryElement.value {
+                string += "=\(value)"
+            }
             if index != query.count - 1 {
                 string += "&"
             }


### PR DESCRIPTION
When a `URI` is converted to a `String`, say when a request is made, it comes out something like "http://example.com/?queryKey=Optional("some_value")" instead of unwrapping the optionals.
